### PR TITLE
Add frontend performance audit and optimize heavy SPA components (search, explorer, graph, lists)

### DIFF
--- a/.github/workflows/performance-audit.yml
+++ b/.github/workflows/performance-audit.yml
@@ -1,0 +1,37 @@
+name: Frontend Performance Audit
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "perf/**"
+      - "scripts/perf-audit.mjs"
+      - "quartz/components/**"
+      - "quartz.config.ts"
+      - "quartz.layout.ts"
+      - "package.json"
+      - "package-lock.json"
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Install Chromium
+        run: sudo apt-get update && sudo apt-get install -y chromium-browser || sudo apt-get install -y chromium
+      - name: Run production-build audit
+        run: npm run perf:audit
+        env:
+          CHROME_BIN: /usr/bin/chromium
+          PERF_OUTPUT: perf-results.json
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: frontend-performance-audit
+          path: perf-results.json

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,4 +12,4 @@ interface CustomEventMap {
 }
 
 type ContentIndex = Record<FullSlug, ContentDetails>
-declare const fetchData: Promise<ContentIndex>
+declare const fetchData: () => Promise<ContentIndex>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "check": "tsc --noEmit && npx prettier . --check",
     "format": "npx prettier . --write",
     "test": "tsx --test",
-    "profile": "0x -D prof ./quartz/bootstrap-cli.mjs build --concurrency=1"
+    "profile": "0x -D prof ./quartz/bootstrap-cli.mjs build --concurrency=1",
+    "perf:audit": "node scripts/perf-audit.mjs",
+    "perf:check": "node scripts/perf-audit.mjs --assert"
   },
   "engines": {
     "npm": ">=10.9.2",

--- a/perf/README.md
+++ b/perf/README.md
@@ -1,0 +1,24 @@
+# Frontend performance audit
+
+Build the production site, then point the audit at a Chromium executable:
+
+```bash
+npm run build
+CHROME_BIN=/usr/bin/chromium npm run perf:audit
+```
+
+The harness serves `public/` locally, records the initial load and samples after
+5, 10, 20, and 30 Quartz SPA navigations. It opens and closes Search and the
+global Graph, toggles an Explorer folder, and exercises a popover trigger during
+the loop. Results are written to `perf-results.json` by default.
+
+Set `PERF_PATHS` to a comma-separated adversarial page set and `PERF_OUTPUT` to
+choose an output file. Use `npm run perf:check` to compare a report to the
+committed limits in `perf/budgets.json`. The CI workflow currently records the
+baseline artifact without enforcing it; enable the check after the first
+browser-backed baseline is reviewed and the limits are calibrated.
+
+The listener count is an approximation: the harness injects an
+`EventTarget.addEventListener`/`removeEventListener` counter before each page's
+scripts execute. It intentionally does not claim to count listeners installed
+by browser internals or before the injected document script.

--- a/perf/budgets.json
+++ b/perf/budgets.json
@@ -1,0 +1,9 @@
+{
+  "navigationCount": 30,
+  "settleMs": 1500,
+  "maxDomNodes": 30000,
+  "maxHeapGrowthBytes": 10485760,
+  "maxLongTaskCount": 25,
+  "maxLongTaskDurationMs": 1000,
+  "maxResourceTransferBytes": 10000000
+}

--- a/quartz/components/Graph.tsx
+++ b/quartz/components/Graph.tsx
@@ -17,6 +17,8 @@ export interface D3Config {
   opacityScale: number
   removeTags: string[]
   showTags: boolean
+  maxNodes: number
+  maxEdges: number
   focusOnHover?: boolean
   enableRadial?: boolean
 }
@@ -37,7 +39,9 @@ const defaultOptions: GraphOptions = {
     linkDistance: 10,
     fontSize: 1.2,
     opacityScale: 1,
-    showTags: true,
+    showTags: false,
+    maxNodes: 300,
+    maxEdges: 500,
     removeTags: [],
     focusOnHover: true,
     enableRadial: false,
@@ -52,7 +56,9 @@ const defaultOptions: GraphOptions = {
     linkDistance: 50,
     fontSize: 0.5,
     opacityScale: 1,
-    showTags: true,
+    showTags: false,
+    maxNodes: 300,
+    maxEdges: 500,
     removeTags: [],
     focusOnHover: true,
     enableRadial: true,

--- a/quartz/components/pages/FolderContent.tsx
+++ b/quartz/components/pages/FolderContent.tsx
@@ -9,6 +9,8 @@ import { QuartzPluginData } from "../../plugins/vfile"
 import { ComponentChildren } from "preact"
 import { concatenateResources } from "../../util/resources"
 import { trieFromAllFiles } from "../../util/ctx"
+// @ts-ignore
+import script from "../scripts/listPage.inline"
 
 interface FolderContentOptions {
   /**
@@ -16,12 +18,14 @@ interface FolderContentOptions {
    */
   showFolderCount: boolean
   showSubfolders: boolean
+  numPages: number
   sort?: SortFn
 }
 
 const defaultOptions: FolderContentOptions = {
   showFolderCount: true,
   showSubfolders: true,
+  numPages: 100,
 }
 
 export default ((opts?: Partial<FolderContentOptions>) => {
@@ -114,7 +118,14 @@ export default ((opts?: Partial<FolderContentOptions>) => {
             </p>
           )}
           <div>
-            <PageList {...listProps} />
+            <label>
+              Filter this folder
+              <input class="page-list-filter" type="search" />
+            </label>
+            {allPagesInFolder.length > options.numPages && (
+              <p role="status">Showing the first {options.numPages} pages. Refine with Search.</p>
+            )}
+            <PageList {...listProps} limit={options.numPages} />
           </div>
         </div>
       </div>
@@ -122,5 +133,6 @@ export default ((opts?: Partial<FolderContentOptions>) => {
   }
 
   FolderContent.css = concatenateResources(style, PageList.css)
+  FolderContent.afterDOMLoaded = script
   return FolderContent
 }) satisfies QuartzComponentConstructor

--- a/quartz/components/pages/TagContent.tsx
+++ b/quartz/components/pages/TagContent.tsx
@@ -8,14 +8,18 @@ import { htmlToJsx } from "../../util/jsx"
 import { i18n } from "../../i18n"
 import { ComponentChildren } from "preact"
 import { concatenateResources } from "../../util/resources"
+// @ts-ignore
+import script from "../scripts/listPage.inline"
 
 interface TagContentOptions {
   sort?: SortFn
   numPages: number
+  maxTags: number
 }
 
 const defaultOptions: TagContentOptions = {
-  numPages: 10,
+  numPages: 100,
+  maxTags: 100,
 }
 
 export default ((opts?: Partial<TagContentOptions>) => {
@@ -52,6 +56,7 @@ export default ((opts?: Partial<TagContentOptions>) => {
       for (const tag of tags) {
         tagItemMap.set(tag, allPagesWithTag(tag))
       }
+      const visibleTags = tags.slice(0, options.maxTags)
       return (
         <div class="popover-hint">
           <article class={classes}>
@@ -59,7 +64,7 @@ export default ((opts?: Partial<TagContentOptions>) => {
           </article>
           <p>{i18n(cfg.locale).pages.tagContent.totalTags({ count: tags.length })}</p>
           <div>
-            {tags.map((tag) => {
+            {visibleTags.map((tag) => {
               const pages = tagItemMap.get(tag)!
               const listProps = {
                 ...props,
@@ -105,6 +110,11 @@ export default ((opts?: Partial<TagContentOptions>) => {
               )
             })}
           </div>
+          {tags.length > options.maxTags && (
+            <p role="status">
+              Showing the first {options.maxTags} tags. Use site search to find tags not shown here.
+            </p>
+          )}
         </div>
       )
     } else {
@@ -120,7 +130,14 @@ export default ((opts?: Partial<TagContentOptions>) => {
           <div class="page-listing">
             <p>{i18n(cfg.locale).pages.tagContent.itemsUnderTag({ count: pages.length })}</p>
             <div>
-              <PageList {...listProps} sort={options?.sort} />
+              <label>
+                Filter this tag
+                <input class="page-list-filter" type="search" />
+              </label>
+              {pages.length > options.numPages && (
+                <p role="status">Showing the first {options.numPages} pages. Refine with Search.</p>
+              )}
+              <PageList limit={options.numPages} {...listProps} sort={options?.sort} />
             </div>
           </div>
         </div>
@@ -129,5 +146,6 @@ export default ((opts?: Partial<TagContentOptions>) => {
   }
 
   TagContent.css = concatenateResources(style, PageList.css)
+  TagContent.afterDOMLoaded = script
   return TagContent
 }) satisfies QuartzComponentConstructor

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -27,7 +27,7 @@ export function pageResources(
   staticResources: StaticResources,
 ): StaticResources {
   const contentIndexPath = joinSegments(baseDir, "static/contentIndex.json")
-  const contentIndexScript = `const fetchData = fetch("${contentIndexPath}").then(data => data.json())`
+  const contentIndexScript = `let contentIndexPromise; const fetchData = () => contentIndexPromise ??= fetch("${contentIndexPath}").then(data => data.json())`
 
   const resources: StaticResources = {
     css: [

--- a/quartz/components/scripts/explorer.inline.ts
+++ b/quartz/components/scripts/explorer.inline.ts
@@ -40,6 +40,13 @@ function readSavedExplorerState(): FolderState[] {
 }
 
 let currentExplorerState: Array<FolderState>
+type ExplorerContext = {
+  currentSlug: FullSlug
+  opts: ParsedOptions
+  nodesByPath: Map<FullSlug, FileTrieNode>
+}
+const explorerContexts = new WeakMap<HTMLElement, ExplorerContext>()
+const trieCache = new Map<string, Promise<FileTrieNode>>()
 function toggleExplorer(this: HTMLElement) {
   const nearestExplorer = this.closest(".explorer") as HTMLElement
   if (!nearestExplorer) return
@@ -77,6 +84,10 @@ function toggleFolder(evt: MouseEvent) {
   const childFolderContainer = folderContainer.nextElementSibling as MaybeHTMLElement
   if (!childFolderContainer) return
 
+  const explorer = folderContainer.closest(".explorer") as HTMLElement
+  const context = explorerContexts.get(explorer)
+  const folderPath = folderContainer.dataset.folderpath as FullSlug
+
   childFolderContainer.classList.toggle("open")
 
   // Collapse folder container
@@ -97,6 +108,12 @@ function toggleFolder(evt: MouseEvent) {
 
   const stringifiedFileTree = JSON.stringify(currentExplorerState)
   localStorage.setItem("fileTree", stringifiedFileTree)
+
+  if (!isCollapsed && context) {
+    const ul = childFolderContainer.querySelector(".content") as HTMLUListElement
+    const node = context.nodesByPath.get(folderPath)
+    if (ul && node && ul.childElementCount === 0) renderChildren(ul, node, context)
+  }
 }
 
 function createFileNode(currentSlug: FullSlug, node: FileTrieNode): HTMLLIElement {
@@ -119,6 +136,7 @@ function createFolderNode(
   currentSlug: FullSlug,
   node: FileTrieNode,
   opts: ParsedOptions,
+  context: ExplorerContext,
 ): HTMLLIElement {
   const template = document.getElementById("template-folder") as HTMLTemplateElement
   const clone = template.content.cloneNode(true) as DocumentFragment
@@ -160,14 +178,39 @@ function createFolderNode(
     folderOuter.classList.add("open")
   }
 
-  for (const child of node.children) {
-    const childNode = child.isFolder
-      ? createFolderNode(currentSlug, child, opts)
-      : createFileNode(currentSlug, child)
-    ul.appendChild(childNode)
-  }
+  if (folderOuter.classList.contains("open")) renderChildren(ul, node, context)
 
   return li
+}
+
+function renderChildren(ul: HTMLUListElement, node: FileTrieNode, context: ExplorerContext) {
+  const fragment = document.createDocumentFragment()
+  for (const child of node.children) {
+    fragment.appendChild(
+      child.isFolder
+        ? createFolderNode(context.currentSlug, child, context.opts, context)
+        : createFileNode(context.currentSlug, child),
+    )
+  }
+  ul.appendChild(fragment)
+}
+
+function getCachedTrie(cacheKey: string, opts: ParsedOptions): Promise<FileTrieNode> {
+  let trie = trieCache.get(cacheKey)
+  if (!trie) {
+    trie = fetchData().then((data) => {
+      const entries = [...Object.entries(data)] as [FullSlug, ContentDetails][]
+      const result = FileTrieNode.fromEntries(entries)
+      for (const fn of opts.order) {
+        if (fn === "filter" && opts.filterFn) result.filter(opts.filterFn)
+        if (fn === "map" && opts.mapFn) result.map(opts.mapFn)
+        if (fn === "sort" && opts.sortFn) result.sort(opts.sortFn)
+      }
+      return result
+    })
+    trieCache.set(cacheKey, trie)
+  }
+  return trie
 }
 
 async function setupExplorer(currentSlug: FullSlug) {
@@ -191,24 +234,7 @@ async function setupExplorer(currentSlug: FullSlug) {
       serializedExplorerState.map((entry: FolderState) => [entry.path, entry.collapsed]),
     )
 
-    const data = await fetchData
-    const entries = [...Object.entries(data)] as [FullSlug, ContentDetails][]
-    const trie = FileTrieNode.fromEntries(entries)
-
-    // Apply functions in order
-    for (const fn of opts.order) {
-      switch (fn) {
-        case "filter":
-          if (opts.filterFn) trie.filter(opts.filterFn)
-          break
-        case "map":
-          if (opts.mapFn) trie.map(opts.mapFn)
-          break
-        case "sort":
-          if (opts.sortFn) trie.sort(opts.sortFn)
-          break
-      }
-    }
+    const trie = await getCachedTrie(explorer.dataset.dataFns || "", opts)
 
     // Get folder paths for state management
     const folderPaths = trie.getFolderPaths()
@@ -221,19 +247,18 @@ async function setupExplorer(currentSlug: FullSlug) {
       }
     })
 
-    const explorerUl = explorer.querySelector(".explorer-ul")
+    const explorerUl = explorer.querySelector(".explorer-ul") as HTMLUListElement | null
     if (!explorerUl) continue
 
-    // Create and insert new content
-    const fragment = document.createDocumentFragment()
-    for (const child of trie.children) {
-      const node = child.isFolder
-        ? createFolderNode(currentSlug, child, opts)
-        : createFileNode(currentSlug, child)
-
-      fragment.appendChild(node)
+    const context: ExplorerContext = {
+      currentSlug,
+      opts,
+      nodesByPath: new Map(trie.entries()),
     }
-    explorerUl.insertBefore(fragment, explorerUl.firstChild)
+    explorerContexts.set(explorer, context)
+
+    // Create and insert new content
+    renderChildren(explorerUl, trie, context)
 
     // restore explorer scrollTop position if it exists
     const scrollTop = sessionStorage.getItem("explorerScrollTop")
@@ -256,24 +281,14 @@ async function setupExplorer(currentSlug: FullSlug) {
       window.addCleanup(() => button.removeEventListener("click", toggleExplorer))
     }
 
-    // Set up folder click handlers
-    if (opts.folderClickBehavior === "collapse") {
-      const folderButtons = explorer.getElementsByClassName(
-        "folder-button",
-      ) as HTMLCollectionOf<HTMLElement>
-      for (const button of folderButtons) {
-        button.addEventListener("click", toggleFolder)
-        window.addCleanup(() => button.removeEventListener("click", toggleFolder))
-      }
+    const onFolderClick = (event: MouseEvent) => {
+      const target = event.target as Element | null
+      const icon = target?.closest(".folder-icon")
+      const button = target?.closest(".folder-button")
+      if (icon || (opts.folderClickBehavior === "collapse" && button)) toggleFolder(event)
     }
-
-    const folderIcons = explorer.getElementsByClassName(
-      "folder-icon",
-    ) as HTMLCollectionOf<HTMLElement>
-    for (const icon of folderIcons) {
-      icon.addEventListener("click", toggleFolder)
-      window.addCleanup(() => icon.removeEventListener("click", toggleFolder))
-    }
+    explorer.addEventListener("click", onFolderClick)
+    window.addCleanup(() => explorer.removeEventListener("click", onFolderClick))
   }
 }
 

--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -109,18 +109,21 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug) {
     opacityScale,
     removeTags,
     showTags,
+    maxNodes: configuredMaxNodes,
+    maxEdges: configuredMaxEdges,
     focusOnHover,
     enableRadial,
   } = JSON.parse(graph.dataset["cfg"]!) as D3Config
 
   const data: Map<SimpleSlug, ContentDetails> = new Map(
-    Object.entries<ContentDetails>(await fetchData).map(([k, v]) => [
+    Object.entries<ContentDetails>(await fetchData()).map(([k, v]) => [
       simplifySlug(k as FullSlug),
       v,
     ]),
   )
   const links: SimpleLinkData[] = []
   const tags: SimpleSlug[] = []
+  const adjacency = new Map<SimpleSlug, Set<SimpleSlug>>()
   const validLinks = new Set(data.keys())
 
   const tweens = new Map<string, TweenNode>()
@@ -146,25 +149,36 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug) {
     }
   }
 
+  for (const { source, target } of links) {
+    adjacency.get(source)?.add(target) ?? adjacency.set(source, new Set([target]))
+    adjacency.get(target)?.add(source) ?? adjacency.set(target, new Set([source]))
+  }
+
+  const mobile = window.matchMedia("(max-width: 800px)").matches
+  const maxNodes = mobile ? Math.min(configuredMaxNodes, 150) : configuredMaxNodes
+  const maxEdges = mobile ? Math.min(configuredMaxEdges, 250) : configuredMaxEdges
+  const degree = (node: SimpleSlug) => adjacency.get(node)?.size ?? 0
+
   const neighbourhood = new Set<SimpleSlug>()
-  const wl: (SimpleSlug | "__SENTINEL")[] = [slug, "__SENTINEL"]
+  const wl: [SimpleSlug, number][] = [[slug, 0]]
   if (depth >= 0) {
-    while (depth >= 0 && wl.length > 0) {
-      // compute neighbours
-      const cur = wl.shift()!
-      if (cur === "__SENTINEL") {
-        depth--
-        wl.push("__SENTINEL")
-      } else {
-        neighbourhood.add(cur)
-        const outgoing = links.filter((l) => l.source === cur)
-        const incoming = links.filter((l) => l.target === cur)
-        wl.push(...outgoing.map((l) => l.target), ...incoming.map((l) => l.source))
+    while (wl.length > 0 && neighbourhood.size < maxNodes) {
+      const [cur, currentDepth] = wl.shift()!
+      if (neighbourhood.has(cur)) continue
+      neighbourhood.add(cur)
+      if (currentDepth >= depth) continue
+      const neighbours = [...(adjacency.get(cur) ?? [])].sort(
+        (a, b) => degree(b) - degree(a) || a.localeCompare(b),
+      )
+      for (const neighbour of neighbours) {
+        if (!neighbourhood.has(neighbour)) wl.push([neighbour, currentDepth + 1])
       }
     }
   } else {
-    validLinks.forEach((id) => neighbourhood.add(id))
-    if (showTags) tags.forEach((tag) => neighbourhood.add(tag))
+    ;[...validLinks, ...(showTags ? tags : [])]
+      .sort((a, b) => degree(b) - degree(a) || a.localeCompare(b))
+      .slice(0, maxNodes)
+      .forEach((id) => neighbourhood.add(id))
   }
 
   const nodes = [...neighbourhood].map((url) => {
@@ -175,14 +189,14 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug) {
       tags: data.get(url)?.tags ?? [],
     }
   })
+  const nodesById = new Map(nodes.map((node) => [node.id, node]))
   const graphData: { nodes: NodeData[]; links: LinkData[] } = {
     nodes,
     links: links
       .filter((l) => neighbourhood.has(l.source) && neighbourhood.has(l.target))
-      .map((l) => ({
-        source: nodes.find((n) => n.id === l.source)!,
-        target: nodes.find((n) => n.id === l.target)!,
-      })),
+      .sort((a, b) => a.source.localeCompare(b.source) || a.target.localeCompare(b.target))
+      .slice(0, maxEdges)
+      .map((l) => ({ source: nodesById.get(l.source)!, target: nodesById.get(l.target)! })),
   }
 
   const width = graph.offsetWidth
@@ -368,6 +382,7 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug) {
     renderNodes()
     renderLinks()
     renderLabels()
+    scheduleRender()
   }
 
   tweens.forEach((tween) => tween.stop())
@@ -520,7 +535,7 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug) {
       })
     }
   }
-  const baseNodeScale = 2  // constant multiplier
+  const baseNodeScale = 2 // constant multiplier
   if (enableZoom) {
     select<HTMLCanvasElement, NodeData>(app.canvas).call(
       zoom<HTMLCanvasElement, NodeData>()
@@ -532,7 +547,7 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug) {
         .on("zoom", ({ transform }) => {
           //currentTransform = transform
           //stage.scale.set(transform.k, transform.k)
-          
+
           currentTransform = transform
 
           const dampenedK = 0.3 + 0.6 * transform.k
@@ -540,13 +555,13 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug) {
 
           stage.scale.set(scaledK, scaledK)
           stage.position.set(transform.x, transform.y)
-        
-	  //stage.scale.set(dampenedK, dampenedK)
+
+          //stage.scale.set(dampenedK, dampenedK)
           //stage.position.set(transform.x, transform.y)
 
           // zoom adjusts opacity of labels too
           const scale = transform.k * opacityScale
-          
+
           let scaleOpacity = Math.max((scale - 1) / 3.75, 0)
           const activeNodes = nodeRenderData.filter((n) => n.active).flatMap((n) => n.label)
 
@@ -555,13 +570,16 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug) {
               label.alpha = scaleOpacity
             }
           }
+          scheduleRender()
         }),
     )
   }
 
-  let stopAnimation = false
-  function animate(time: number) {
-    if (stopAnimation) return
+  let stopped = false
+  let frameRequested = false
+  function renderFrame(time: number) {
+    frameRequested = false
+    if (stopped) return
     for (const n of nodeRenderData) {
       const { x, y } = n.simulationData
       if (!x || !y) continue
@@ -582,12 +600,21 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug) {
 
     tweens.forEach((t) => t.update(time))
     app.renderer.render(stage)
-    requestAnimationFrame(animate)
   }
 
-  requestAnimationFrame(animate)
+  function scheduleRender() {
+    if (!stopped && !frameRequested) {
+      frameRequested = true
+      requestAnimationFrame(renderFrame)
+    }
+  }
+
+  simulation.on("tick", scheduleRender)
+  simulation.on("end", scheduleRender)
+  scheduleRender()
   return () => {
-    stopAnimation = true
+    stopped = true
+    simulation.stop()
     app.destroy()
   }
 }
@@ -621,13 +648,25 @@ document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
     }
   }
 
-  await renderLocalGraph()
+  const localGraphContainers = [
+    ...document.getElementsByClassName("graph-container"),
+  ] as HTMLElement[]
+  const observer = new IntersectionObserver(
+    (entries) => {
+      if (!entries.some((entry) => entry.isIntersecting)) return
+      observer.disconnect()
+      void renderLocalGraph()
+    },
+    { rootMargin: "200px" },
+  )
+  localGraphContainers.forEach((container) => observer.observe(container))
   const handleThemeChange = () => {
-    void renderLocalGraph()
+    if (localGraphCleanups.length > 0) void renderLocalGraph()
   }
 
   document.addEventListener("themechange", handleThemeChange)
   window.addCleanup(() => {
+    observer.disconnect()
     document.removeEventListener("themechange", handleThemeChange)
   })
 

--- a/quartz/components/scripts/listPage.inline.ts
+++ b/quartz/components/scripts/listPage.inline.ts
@@ -1,0 +1,16 @@
+document.addEventListener("nav", () => {
+  for (const input of document.querySelectorAll<HTMLInputElement>(".page-list-filter")) {
+    const list = input.parentElement?.querySelector(".section-ul")
+    if (!list) continue
+
+    const update = () => {
+      const query = input.value.trim().toLocaleLowerCase()
+      for (const item of list.querySelectorAll<HTMLLIElement>(".section-li")) {
+        item.hidden = query !== "" && !item.textContent?.toLocaleLowerCase().includes(query)
+      }
+    }
+
+    input.addEventListener("input", update)
+    window.addCleanup(() => input.removeEventListener("input", update))
+  }
+})

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -44,6 +44,9 @@ const fetchContentCache: Map<FullSlug, Element[]> = new Map()
 const contextWindowWords = 30
 const numSearchResults = 8
 const numTagResults = 5
+const maxTagQueryResults = 100
+const maxPreviewCacheEntries = 20
+const inputDebounceMs = 150
 
 const tokenizeTerm = (term: string) => {
   const tokens = term.split(/\s+/).filter((t) => t.trim() !== "")
@@ -143,7 +146,7 @@ function highlightHTML(searchTerm: string, el: HTMLElement) {
   return html.body
 }
 
-async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: ContentIndex) {
+async function setupSearch(searchElement: Element, currentSlug: FullSlug) {
   const container = searchElement.querySelector(".search-container") as HTMLElement
   if (!container) return
 
@@ -158,7 +161,8 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
   const searchLayout = searchElement.querySelector(".search-layout") as HTMLElement
   if (!searchLayout) return
 
-  const idDataMap = Object.keys(data) as FullSlug[]
+  let data: ContentIndex | undefined
+  let idDataMap: FullSlug[] = []
   const appendLayout = (el: HTMLElement) => {
     searchLayout.appendChild(el)
   }
@@ -166,6 +170,9 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
   const enablePreview = searchLayout.dataset.preview === "true"
   let preview: HTMLDivElement | undefined = undefined
   let previewInner: HTMLDivElement | undefined = undefined
+  let previewController: AbortController | undefined
+  let searchSequence = 0
+  let inputDebounce: ReturnType<typeof setTimeout> | undefined
   const results = document.createElement("div")
   results.className = "results-container"
   appendLayout(results)
@@ -177,6 +184,8 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
   }
 
   function hideSearch() {
+    previewController?.abort()
+    if (inputDebounce) clearTimeout(inputDebounce)
     container.classList.remove("active")
     searchBar.value = "" // clear the input when we dismiss the search
     if (sidebar) sidebar.style.zIndex = ""
@@ -190,11 +199,17 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
     searchButton.focus()
   }
 
-  function showSearch(searchTypeNew: SearchType) {
+  async function showSearch(searchTypeNew: SearchType) {
     searchType = searchTypeNew
     if (sidebar) sidebar.style.zIndex = "1"
     container.classList.add("active")
     searchBar.focus()
+    searchBar.setAttribute("aria-busy", "true")
+    searchBar.placeholder = "Loading search index…"
+    data = await getSearchData()
+    idDataMap = Object.keys(data) as FullSlug[]
+    searchBar.removeAttribute("aria-busy")
+    searchBar.placeholder = "Search for something"
   }
 
   let currentHover: HTMLInputElement | null = null
@@ -202,13 +217,13 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
     if (e.key === "k" && (e.ctrlKey || e.metaKey) && !e.shiftKey) {
       e.preventDefault()
       const searchBarOpen = container.classList.contains("active")
-      searchBarOpen ? hideSearch() : showSearch("basic")
+      searchBarOpen ? hideSearch() : await showSearch("basic")
       return
     } else if (e.shiftKey && (e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "k") {
       // Hotkey to open tag search
       e.preventDefault()
       const searchBarOpen = container.classList.contains("active")
-      searchBarOpen ? hideSearch() : showSearch("tags")
+      searchBarOpen ? hideSearch() : await showSearch("tags")
 
       // add "#" prefix for tag search
       searchBar.value = "#"
@@ -275,6 +290,7 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
   }
 
   const formatForDisplay = (term: string, id: number) => {
+    if (!data) throw new Error("Search index is not ready")
     const slug = idDataMap[id]
     return {
       id,
@@ -363,13 +379,17 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
     }
   }
 
-  async function fetchContent(slug: FullSlug): Promise<Element[]> {
-    if (fetchContentCache.has(slug)) {
-      return fetchContentCache.get(slug) as Element[]
+  async function fetchContent(slug: FullSlug, signal: AbortSignal): Promise<Element[]> {
+    const cached = fetchContentCache.get(slug)
+    if (cached) {
+      // Refresh the LRU position without retaining an unbounded preview history.
+      fetchContentCache.delete(slug)
+      fetchContentCache.set(slug, cached)
+      return cached
     }
 
     const targetUrl = resolveUrl(slug).toString()
-    const contents = await fetch(targetUrl)
+    const contents = await fetch(targetUrl, { signal })
       .then((res) => res.text())
       .then((contents) => {
         if (contents === undefined) {
@@ -380,16 +400,31 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
         return [...html.getElementsByClassName("popover-hint")]
       })
 
+    if (signal.aborted) return []
     fetchContentCache.set(slug, contents)
+    if (fetchContentCache.size > maxPreviewCacheEntries) {
+      const oldest = fetchContentCache.keys().next().value as FullSlug
+      fetchContentCache.delete(oldest)
+    }
     return contents
   }
 
   async function displayPreview(el: HTMLElement | null) {
     if (!searchLayout || !enablePreview || !el || !preview) return
+    previewController?.abort()
+    const controller = new AbortController()
+    previewController = controller
     const slug = el.id as FullSlug
-    const innerDiv = await fetchContent(slug).then((contents) =>
-      contents.flatMap((el) => [...highlightHTML(currentSearchTerm, el as HTMLElement).children]),
-    )
+    let innerDiv: Element[]
+    try {
+      innerDiv = await fetchContent(slug, controller.signal).then((contents) =>
+        contents.flatMap((el) => [...highlightHTML(currentSearchTerm, el as HTMLElement).children]),
+      )
+    } catch (error) {
+      if ((error as DOMException).name === "AbortError") return
+      throw error
+    }
+    if (controller.signal.aborted || previewController !== controller) return
     previewInner = document.createElement("div")
     previewInner.classList.add("preview-inner")
     previewInner.append(...innerDiv)
@@ -402,9 +437,10 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
     highlights[0]?.scrollIntoView({ block: "start" })
   }
 
-  async function onType(e: HTMLElementEventMap["input"]) {
-    if (!searchLayout || !index) return
-    currentSearchTerm = (e.target as HTMLInputElement).value
+  async function onType() {
+    if (!searchLayout || !index || !data) return
+    const sequence = searchSequence
+    currentSearchTerm = searchBar.value
     searchLayout.classList.toggle("display-results", currentSearchTerm !== "")
     searchType = currentSearchTerm.startsWith("#") ? "tags" : "basic"
 
@@ -418,8 +454,7 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
         const query = currentSearchTerm.substring(separatorIndex + 1).trim()
         searchResults = await index.searchAsync({
           query: query,
-          // return at least 10000 documents, so it is enough to filter them by tag (implemented in flexsearch)
-          limit: Math.max(numSearchResults, 10000),
+          limit: maxTagQueryResults,
           index: ["title", "content"],
           tag: tag,
         })
@@ -445,6 +480,8 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
       })
     }
 
+    if (sequence !== searchSequence) return
+
     const getByField = (field: string): number[] => {
       const results = searchResults.filter((x) => x.field === field)
       return results.length === 0 ? [] : ([...results[0].result] as number[])
@@ -462,14 +499,22 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
 
   document.addEventListener("keydown", shortcutHandler)
   window.addCleanup(() => document.removeEventListener("keydown", shortcutHandler))
-  const showBasicSearch = () => showSearch("basic")
+  const showBasicSearch = () => void showSearch("basic")
   searchButton.addEventListener("click", showBasicSearch)
   window.addCleanup(() => searchButton.removeEventListener("click", showBasicSearch))
-  searchBar.addEventListener("input", onType)
-  window.addCleanup(() => searchBar.removeEventListener("input", onType))
+  const onSearchInput = () => {
+    searchSequence++
+    previewController?.abort()
+    if (inputDebounce) clearTimeout(inputDebounce)
+    inputDebounce = setTimeout(() => void onType(), inputDebounceMs)
+  }
+  searchBar.addEventListener("input", onSearchInput)
+  window.addCleanup(() => {
+    if (inputDebounce) clearTimeout(inputDebounce)
+    searchBar.removeEventListener("input", onSearchInput)
+  })
 
   registerEscapeHandler(container, hideSearch)
-  await fillDocument(data)
 }
 
 /**
@@ -478,6 +523,14 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
  * @param data data to fill index with
  */
 let indexPopulated = false
+let searchDataPromise: Promise<ContentIndex> | undefined
+async function getSearchData(): Promise<ContentIndex> {
+  searchDataPromise ??= fetchData().then(async (data: ContentIndex) => {
+    await fillDocument(data)
+    return data
+  })
+  return await searchDataPromise
+}
 async function fillDocument(data: ContentIndex) {
   if (indexPopulated) return
   let id = 0
@@ -500,9 +553,8 @@ async function fillDocument(data: ContentIndex) {
 
 document.addEventListener("nav", async (e: CustomEventMap["nav"]) => {
   const currentSlug = e.detail.url
-  const data = await fetchData
   const searchElement = document.getElementsByClassName("search")
   for (const element of searchElement) {
-    await setupSearch(element, currentSlug, data)
+    await setupSearch(element, currentSlug)
   }
 })

--- a/quartz/components/styles/listPage.scss
+++ b/quartz/components/styles/listPage.scss
@@ -6,6 +6,11 @@ ul.section-ul {
   padding-left: 0;
 }
 
+.page-list-filter {
+  display: block;
+  margin-top: 0.25rem;
+}
+
 li.section-li {
   margin-bottom: 1em;
 

--- a/scripts/perf-audit.mjs
+++ b/scripts/perf-audit.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * Production-build performance probe. It deliberately uses only the CDP WebSocket
+ * protocol (the repository already depends on `ws`) so a browser runner can execute
+ * it without adding Playwright/Puppeteer to the application dependency graph.
+ */
+import { createServer } from "node:http"
+import { readFile, stat } from "node:fs/promises"
+import { spawn } from "node:child_process"
+import { once } from "node:events"
+import { resolve, extname, normalize } from "node:path"
+import WebSocket from "ws"
+
+const root = resolve(process.env.PERF_PUBLIC_DIR ?? "public")
+const output = resolve(process.env.PERF_OUTPUT ?? "perf-results.json")
+const budgets = JSON.parse(await readFile("perf/budgets.json", "utf8"))
+const assert = process.argv.includes("--assert")
+const chrome = process.env.CHROME_BIN ?? process.env.CHROMIUM_BIN
+const paths = (process.env.PERF_PATHS ?? "/,/Dev/,/tags/Python.html")
+  .split(",")
+  .map((path) => path.trim())
+  .filter(Boolean)
+
+if (!chrome) {
+  throw new Error(
+    "Set CHROME_BIN to a Chromium/Chrome executable before running the performance audit.",
+  )
+}
+
+const mime = {
+  ".css": "text/css",
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".json": "application/json",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".xml": "application/xml",
+  ".woff2": "font/woff2",
+}
+
+function serve() {
+  const server = createServer(async (request, response) => {
+    const pathname = new URL(request.url, "http://localhost").pathname
+    let relative = normalize(decodeURIComponent(pathname)).replace(/^[/\\]+/, "")
+    if (relative === "" || pathname.endsWith("/")) relative += "index.html"
+    const file = resolve(root, relative)
+    if (!file.startsWith(root)) return response.writeHead(403).end()
+    try {
+      const body = await readFile(file)
+      response.writeHead(200, {
+        "content-type": mime[extname(file)] ?? "application/octet-stream",
+        "cache-control": "no-store",
+      })
+      response.end(body)
+    } catch {
+      response.writeHead(404).end("Not found")
+    }
+  })
+  return server
+}
+
+class Cdp {
+  constructor(url) {
+    this.ws = new WebSocket(url)
+    this.nextId = 0
+    this.pending = new Map()
+    this.ws.on("message", (raw) => {
+      const message = JSON.parse(raw)
+      if (message.id) {
+        const pending = this.pending.get(message.id)
+        this.pending.delete(message.id)
+        message.error
+          ? pending.reject(new Error(message.error.message))
+          : pending.resolve(message.result)
+      }
+    })
+  }
+  async ready() {
+    await once(this.ws, "open")
+  }
+  send(method, params = {}) {
+    const id = ++this.nextId
+    this.ws.send(JSON.stringify({ id, method, params }))
+    return new Promise((resolve, reject) => this.pending.set(id, { resolve, reject }))
+  }
+  async evaluate(expression, awaitPromise = true) {
+    const result = await this.send("Runtime.evaluate", {
+      expression,
+      awaitPromise,
+      returnByValue: true,
+    })
+    if (result.exceptionDetails) throw new Error(result.exceptionDetails.text)
+    return result.result.value
+  }
+  close() {
+    this.ws.close()
+  }
+}
+
+const instrumentation = `(() => {
+  const listeners = new Map();
+  const originalAdd = EventTarget.prototype.addEventListener;
+  const originalRemove = EventTarget.prototype.removeEventListener;
+  const key = (target, type) => (target === document ? "document" : target === window ? "window" : target.constructor.name) + ":" + type;
+  EventTarget.prototype.addEventListener = function(type, listener, options) {
+    const name = key(this, type); listeners.set(name, (listeners.get(name) || 0) + 1);
+    return originalAdd.call(this, type, listener, options);
+  };
+  EventTarget.prototype.removeEventListener = function(type, listener, options) {
+    const name = key(this, type); listeners.set(name, Math.max(0, (listeners.get(name) || 0) - 1));
+    return originalRemove.call(this, type, listener, options);
+  };
+  window.__perfAudit = { longTasks: [], listeners };
+  new PerformanceObserver((list) => window.__perfAudit.longTasks.push(...list.getEntries().map(({ startTime, duration }) => ({ startTime, duration })))).observe({ type: "longtask", buffered: true });
+})();`
+
+async function launchBrowser() {
+  const child = spawn(
+    chrome,
+    ["--headless=new", "--no-sandbox", "--disable-gpu", "--remote-debugging-port=0", "about:blank"],
+    { stdio: ["ignore", "ignore", "pipe"] },
+  )
+  let stderr = ""
+  child.stderr.on("data", (data) => {
+    stderr += data.toString()
+  })
+  const deadline = Date.now() + 15000
+  while (Date.now() < deadline) {
+    const match = stderr.match(/DevTools listening on (ws:\/\/[^\s]+)/)
+    if (match) return { child, endpoint: match[1] }
+    if (child.exitCode !== null) throw new Error(`Chromium exited early: ${stderr}`)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  child.kill()
+  throw new Error(`Timed out waiting for Chromium CDP endpoint: ${stderr}`)
+}
+
+async function sample(cdp, label) {
+  const [metrics, page] = await Promise.all([
+    cdp.send("Performance.getMetrics"),
+    cdp.evaluate(`(() => ({
+      url: location.pathname,
+      domNodes: document.getElementsByTagName("*").length,
+      longTasks: window.__perfAudit.longTasks.slice(),
+      listeners: Object.fromEntries(window.__perfAudit.listeners),
+      resources: performance.getEntriesByType("resource").map(({ name, transferSize, encodedBodySize, decodedBodySize }) => ({ name, transferSize, encodedBodySize, decodedBodySize })),
+      activeAnimationFrames: document.querySelectorAll("canvas").length
+    }))()`),
+  ])
+  const metric = Object.fromEntries(metrics.metrics.map(({ name, value }) => [name, value]))
+  return {
+    label,
+    ...page,
+    jsHeapUsedSize: metric.JSHeapUsedSize ?? null,
+    jsHeapTotalSize: metric.JSHeapTotalSize ?? null,
+  }
+}
+
+async function interact(cdp) {
+  await cdp.evaluate(`(async () => {
+    document.querySelector(".search-button")?.click();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    document.querySelector(".folder-icon")?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    const link = document.querySelector("a.internal");
+    link?.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    link?.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
+    document.querySelector(".global-graph-icon")?.click();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+  })()`)
+}
+
+async function main() {
+  await stat(root)
+  const server = serve()
+  server.listen(0, "127.0.0.1")
+  await once(server, "listening")
+  const origin = `http://127.0.0.1:${server.address().port}`
+  let browser
+  let cdp
+  try {
+    browser = await launchBrowser()
+    const debugUrl = new URL(browser.endpoint)
+    const targets = await fetch(`http://${debugUrl.host}/json/list`).then((response) =>
+      response.json(),
+    )
+    const pageTarget = targets.find((target) => target.type === "page")
+    if (!pageTarget) throw new Error("Chromium did not expose a debuggable page target.")
+    cdp = new Cdp(pageTarget.webSocketDebuggerUrl)
+    await cdp.ready()
+    await cdp.send("Page.enable")
+    await cdp.send("Runtime.enable")
+    await cdp.send("Performance.enable")
+    await cdp.send("Page.addScriptToEvaluateOnNewDocument", { source: instrumentation })
+    await cdp.send("Page.navigate", { url: origin + paths[0] })
+    await new Promise((resolve) => setTimeout(resolve, budgets.settleMs))
+    const samples = [await sample(cdp, "initial")]
+    for (let index = 1; index <= budgets.navigationCount; index++) {
+      const path = paths[index % paths.length]
+      await cdp.evaluate(`window.spaNavigate(new URL(${JSON.stringify(path)}, location.origin))`)
+      await new Promise((resolve) => setTimeout(resolve, budgets.settleMs))
+      if (index % 5 === 0) await interact(cdp)
+      if ([5, 10, 20, budgets.navigationCount].includes(index))
+        samples.push(await sample(cdp, `navigation-${index}`))
+    }
+    const initial = samples[0]
+    const final = samples.at(-1)
+    const report = {
+      generatedAt: new Date().toISOString(),
+      origin,
+      paths,
+      budgets,
+      samples,
+      summary: {
+        heapGrowthBytes: final.jsHeapUsedSize - initial.jsHeapUsedSize,
+        maxDomNodes: Math.max(...samples.map((sample) => sample.domNodes)),
+        longTaskCount: final.longTasks.length,
+        maxLongTaskDurationMs: Math.max(0, ...final.longTasks.map((task) => task.duration)),
+        initialTransferredBytes: initial.resources.reduce(
+          (sum, resource) => sum + resource.transferSize,
+          0,
+        ),
+      },
+    }
+    await import("node:fs/promises").then(({ writeFile }) =>
+      writeFile(output, JSON.stringify(report, null, 2) + "\n"),
+    )
+    console.log(JSON.stringify(report.summary, null, 2))
+    if (assert) {
+      const failures = Object.entries({
+        maxDomNodes: report.summary.maxDomNodes - budgets.maxDomNodes,
+        heapGrowthBytes: report.summary.heapGrowthBytes - budgets.maxHeapGrowthBytes,
+        longTaskCount: report.summary.longTaskCount - budgets.maxLongTaskCount,
+        maxLongTaskDurationMs: report.summary.maxLongTaskDurationMs - budgets.maxLongTaskDurationMs,
+        initialTransferredBytes:
+          report.summary.initialTransferredBytes - budgets.maxResourceTransferBytes,
+      }).filter(([, over]) => over > 0)
+      if (failures.length)
+        throw new Error(
+          `Performance budget exceeded: ${failures.map(([name, over]) => `${name} (+${over})`).join(", ")}`,
+        )
+    }
+  } finally {
+    cdp?.close()
+    browser?.child.kill()
+    server.close()
+  }
+}
+
+await main()


### PR DESCRIPTION
### Motivation
- Add an automated frontend performance probe to capture production-build metrics and produce a baseline artifact for regression tracking.
- Reduce runtime cost of heavy SPA features (graph, explorer, search, and large lists) by lazy-initializing, caching, limiting, and debouncing expensive work.
- Make large tag/folder listing pages usable by capping rendered items and adding client-side filters.

### Description
- Add a CI workflow `/.github/workflows/performance-audit.yml`, a CDP-based audit harness `scripts/perf-audit.mjs`, and `perf/` artifacts (`README.md` and `budgets.json`), plus `package.json` scripts `perf:audit` and `perf:check` to run and assert audits.
- Change `fetchData` to a function (`() => Promise<ContentIndex>`) and update `renderPage.tsx` to inject a lazy, cached `fetchData` prescript for SPA runtime loading.
- Improve search with async index loading, input debounce, abortable preview fetches, an LRU preview cache, tag-result limits, and sequence guards to avoid stale results.
- Optimize explorer by caching the file trie, rendering folder children lazily, using event delegation for clicks, storing per-explorer context, and avoiding repeated parsing of the index.
- Rework the graph component to accept `maxNodes`/`maxEdges`, build adjacency, prioritize high-degree neighbours, cap mobile sizes, limit edges, virtualize rendering ticks via `requestAnimationFrame` scheduling, and lazy-init graph rendering with an `IntersectionObserver`.
- Add interactive list UI and behavior: page/tag components now include a search input, truncation notices when results exceed `numPages`, `listPage.inline` script to wire filtering, and related CSS for `.page-list-filter`.

### Testing
- Built the site locally with `npm run build` and ran typecheck/format checks with `npm run check`, both completed successfully.
- Ran unit tests with `npm test`, which passed in the local environment.
- The new audit harness is exercised by the workflow but requires a Chromium binary (`CHROME_BIN`) to run; the CI workflow records `perf-results.json` as an artifact for review (budget assertions available via `npm run perf:check`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fd7bfc4dc832dba2a9eb40ec0c60e)