### PR TITLE
Enforce journal performance budgets in CI

### DIFF
--- a/.github/workflows/performance-audit.yml
+++ b/.github/workflows/performance-audit.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - ".github/workflows/performance-audit.yml"
       - "perf/**"
       - "scripts/perf-audit.mjs"
       - "quartz/components/**"
@@ -19,17 +20,23 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build
-      - name: Install Chromium
-        run: sudo apt-get update && sudo apt-get install -y chromium-browser || sudo apt-get install -y chromium
-      - name: Run production-build audit
-        run: npm run perf:audit
+      - name: Install and locate Chromium
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y chromium-browser || sudo apt-get install -y chromium
+          CHROME_BIN="$(command -v chromium || command -v chromium-browser)"
+          test -x "$CHROME_BIN"
+          "$CHROME_BIN" --version
+          echo "CHROME_BIN=$CHROME_BIN" >> "$GITHUB_ENV"
+      - name: Enforce production performance budgets
+        run: npm run perf:check
         env:
-          CHROME_BIN: /usr/bin/chromium
           PERF_OUTPUT: perf-results.json
+          PERF_PATHS: "/,/Dev/,/tags/Python.html"
       - uses: actions/upload-artifact@v4
         if: always()
         with:


### PR DESCRIPTION
## Summary

- run the asserting `npm run perf:check` command instead of the non-enforcing audit
- align the job with the repository's declared Node.js 22 runtime
- discover the installed Chromium executable, validate it, and print its version
- make the workflow trigger on changes to itself
- declare the bounded representative paths explicitly and retain artifact upload on failure

## Why

The existing job builds the site and records `perf-results.json`, but `npm run perf:audit` never asserts the budgets. Performance regressions can therefore leave the check green. This addresses the central enforcement gap in #30.

## Impact audit

This changes CI policy only: relevant pull requests will now fail when the existing budgets are exceeded. It does not change budgets, application code, dependencies, generated site content, or deployment behavior. Rollback is a one-file workflow revert.

## Verification

- [x] Diff is one workflow file, one commit ahead of current `main`
- [x] Workflow self-triggered and checkout, Node setup, install, build, and Chromium discovery succeeded
- [x] Runtime evidence: Node 22.23.2; Chromium 151.0.7922.108
- [x] `perf-results.json` uploaded on failure as artifact 9280266877
- [x] DOM nodes, long tasks, long-task duration, and initial transfer remained within budget
- [ ] Heap-growth budget passes

## Observed budget failure

- Initial heap used: 14,938,960 bytes
- Final heap used after 30 navigations: 68,680,484 bytes
- Growth: 53,741,524 bytes
- Budget: 10,485,760 bytes
- Excess: 43,255,764 bytes

The draft is intentionally left failing. The budget has not been loosened, and frontend behavior has not been changed.

## Judgment / follow-up

Before this enforcement can merge, either diagnose and repair the observed heap growth in a separate bounded change, or explicitly recalibrate the budget using an evidence-backed baseline. A fully pinned browser revision and matching local documentation also remain acceptance criteria for closing #30.